### PR TITLE
theme: Split SITENAME in to SITENAME & SITENAME_EXTRA

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -3,7 +3,8 @@
 from __future__ import unicode_literals
 
 AUTHOR = u'Interlock Member'
-SITENAME = u'Interlock Rochester - Rochester\'s Hackerspace'
+SITENAME = u'Interlock Rochester'
+SITENAME_EXTRA = u'Rochester\'s Hackerspace'
 SITEURL = 'https://interlockroc.org'
 
 #FRONT_PIC_BACKGROUND = 'cut_wood_crop.jpg'

--- a/themes/clean-blog/templates/base.html
+++ b/themes/clean-blog/templates/base.html
@@ -81,7 +81,7 @@
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                 </button>
-                <a class="navbar-brand" href="{{ SITEURL }}/">{{ SITENAME }}</a>
+                <a class="navbar-brand" href="{{ SITEURL }}/">{{ SITENAME }}{% if SITENAME_EXTRA %}<span class="hidden-xs"> - {{ SITENAME_EXTRA }}</span>{% endif %}</a>
             </div>
 
             <!-- Collect the nav links, forms, and other content for toggling -->


### PR DESCRIPTION
This moves the extra text "Rochester's Hackerspace" over into a span that will hide on "extra small" screens (<768px wide).

This resolves #11